### PR TITLE
Add working directory as git's safe.directory when pkg is '.'

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -125,6 +125,11 @@ if [ -n "$pkgsysdeps" ]; then
     apt-get install -y $pkgsysdeps || exit $?
 fi
 
+# If installing a local package, add it to the safe.directory
+if [ "$pkgurl" == "." ]; then
+    /usr/bin/git config --global --add safe.directory $(pwd)
+fi
+
 $dir/zkg.sh --pkg "$pkgurl" --pkg-version "$pkgver" --pkg-uservars "${pkguservars[@]}"
 res=$?
 


### PR DESCRIPTION
During https://github.com/zeek/zeek-af_packet-plugin/pull/48 it became apparent that this action
action is affected by the fix for CVE-2022-24765[1]. As a fix, ad the current
working directory to the git's global safe.directory when running entrypoint.sh

Unfortunately, the error wasn't immediately obvious, because
a `git diff --cached` reports "error: unknown option 'cached'",
while `git status` reports "dubious ownership". Introduce a
new parameter to add safe.directory on $(pwd) when installing
a package from a checkout via zkg install .

[1] https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765
