### PR TITLE
Allow using new versioned Zeek packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
           - zeek
           - zeek-lts
           - zeek-nightly
+          - zeek-5.0
+          - zeek-6.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Run a cron job on Monday at 3:42 AM.
+    - cron: '42 3 * * 1'
+
+jobs:
+  run_action:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - zeek
+          - zeek-lts
+          - zeek-nightly
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Install zkg
+        run: |
+          pip3 install zkg
+      - name: Set up test repo
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+
+          zkg create --packagedir test --user-var name=Foo
+      - name: Run action
+        uses: ./
+        with:
+          pkg: test
+          load_packages: true
+          zeek_version: ${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The action supports the following inputs:
   [binary packages](https://github.com/zeek/zeek/wiki/Binary-Packages):
   `zeek` for the latest release, `zeek-lts` for the latest
   long-term-support release, and `zeek-nightly` for the latest nightly
-  Zeek build.
+  Zeek build. LTS release versions can also be pinned using `zeek-6.0`.
 
 - `load_packages`: when enabled (by passing `yes`, `true`, or `1`), a
   successful package installation via zkg is followed by a parse-only

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ''
   zeek_version:
-    description: 'Zeek version (zeek/zeek-lts/zeek-nightly, from the OBS builds)'
+    description: 'Zeek version (zeek/zeek-lts/zeek-nightly/zeek-X.Y, from the OBS builds)'
     required: false
     default: 'zeek'
   load_packages:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -39,6 +39,7 @@ Arguments:
     - "zeek": latest released Zeek version (default)
     - "zeek-lts": long-term support version
     - "zeek-nightly": latest nightly build
+    - "zeek-X.0": explicitly versioned LTS package
 
   -l|--load-packages <yes|no>
 

--- a/scripts/zeek-install.sh
+++ b/scripts/zeek-install.sh
@@ -9,8 +9,8 @@ if [ -z "$package" ]; then
     exit 1
 fi
 
-if ! [[ "$package" =~ ^(zeek|zeek-lts|zeek-nightly)$ ]]; then
-    echo "Zeek package version must be 'zeek', 'zeek-lts', or 'zeek-nightly'."
+if ! [[ "$package" =~ ^(zeek|zeek-lts|zeek-nightly|zeek-[0-9]+\.0)$ ]]; then
+    echo "Zeek package version must be 'zeek', 'zeek-lts', 'zeek-nightly' or 'zeek-<LTS version>.0'."
     exit 1
 fi
 


### PR DESCRIPTION
This PR add changes so one can use the versioned flavor of our Zeek packages as `zeek_version`, e.g., this now allows `zeek-6` instead of forcing users to use `zeek`.

The changes here are minimal. I did not try to tackle e.g., #7.