### PR TITLE
Bump Docker image and distro use from Debian 11 to 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:11
-LABEL maintainer="Christian Kreibich <christian@corelight.com>"
+FROM debian:13
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -14,9 +13,9 @@ RUN apt-get -y install bison bzip2 cmake curl flex g++ gcc git gpg libmaxminddb-
 
 # Set up repo to install from SUSE OBS, as per
 # https://software.opensuse.org//download.html?project=security%3Azeek&package=zeek-nightly:
-RUN echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_11/ /' \
+RUN echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_13/ /' \
     | tee /etc/apt/sources.list.d/security:zeek.list
-RUN curl -fsSL -m 15 https://download.opensuse.org/repositories/security:zeek/Debian_11/Release.key \
+RUN curl -fsSL -m 15 https://download.opensuse.org/repositories/security:zeek/Debian_13/Release.key \
     | gpg --dearmor \
     | tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Github Action for Testing Zeek Packages
 
 This is a Github Action that will run `zkg install` on a Zeek
-package. It currently runs Debian 10 via Docker, but we may broaden
-support to additional distros and platforms in the future.
+package for a variety of Zeek versions. It runs Debian 13 via Docker.
 
 ## Input arguments
 


### PR DESCRIPTION
This means actions were running with binary packages still available for Debian 11, so not including 8.1 or newer (including nightlies).